### PR TITLE
I've improved how filenames are displayed and made sure README_KOR.md…

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sortedFilenames.forEach(filename => {
         const li = document.createElement('li');
-        li.textContent = filename;
+        li.textContent = filename.split('/').pop();
         li.setAttribute('data-filename', filename);
         li.addEventListener('click', () => {
             // Remove active class from other items


### PR DESCRIPTION
… loads correctly.

Here's what I did:
- I updated `script.js` so that you'll now see just the filename (like "MyFile.md") in the list, instead of the full path (like "markdown_files/MyFile.md").
- Don't worry, I'm still using the full path internally to get the content.
- This change should make the file list less confusing for you.

This also includes some earlier improvements:
- I moved `markdown_files/README_KOR.md` to the main directory and renamed it to `README_KOR.md`.
- I updated `md_content.js` to point to the new location of `README_KOR.md`.
- I made sure `md_content.js` loads before `script.js` and removed some unnecessary code from `script.js`.