### PR TITLE
Fix missing script tags for Markdown viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,9 @@
             </ul>
         </div>
     </div>
-    <!-- Script tags for marked.min.js, md_content.js, and script.js have been removed -->
+    <!-- Load the Markdown parser and dynamic content scripts -->
+    <script src="./node_modules/marked/marked.min.js"></script>
+    <script src="./md_content.js"></script>
+    <script src="./script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore script tags in `index.html` so Markdown files load dynamically

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684115b27a888326a382e1f5859c6a5e